### PR TITLE
Fix globally reported CO2 AFOLU

### DIFF
--- a/data/raw/scenarios/0020/versions.json
+++ b/data/raw/scenarios/0020/versions.json
@@ -1,4 +1,15 @@
 {
+  "AIM 3.0": {
+    "SSP1 - Medium Emissions": 15,
+    "SSP1 - Very Low Emissions": 32,
+    "SSP1 - Very Low Emissions_a": 8,
+    "SSP2 - Low Emissions": 32,
+    "SSP2 - Low Emissions_a": 4,
+    "SSP2 - Low Overshoot": 33,
+    "SSP2 - Low Overshoot_d": 8,
+    "SSP2 - Low Overshoot_e": 1,
+    "SSP2 - Low Overshoot_f": 1
+  },
   "GCAM 7.1 scenarioMIP": {
     "SSP2 - High Emissions": 6,
     "SSP3 - High Emissions": 21,

--- a/notebooks/5093_pre-processing.py
+++ b/notebooks/5093_pre-processing.py
@@ -217,6 +217,26 @@ model_df = model_df.loc[~pix.ismatch(variable="Emissions|C2F6|**")]
 pre_processing_res = pre_processor(model_df)
 
 # %%
+# Hard override the global workflow emissions for CO2 AFOLU
+# to use globally reported numbers,
+# even if they're not consistent with region-sector reporting.
+pre_processing_res.global_workflow_emissions = pix.concat(
+    [
+        pre_processing_res.global_workflow_emissions.loc[~pix.isin(variable="Emissions|CO2|Biosphere")],
+        model_df.loc[pix.isin(variable="Emissions|CO2|AFOLU", region="World")].pix.assign(
+            variable="Emissions|CO2|Biosphere"
+        ),
+    ]
+)
+
+pre_processing_res.global_workflow_emissions_raw_names = pix.concat(
+    [
+        pre_processing_res.global_workflow_emissions_raw_names.loc[~pix.isin(variable="Emissions|CO2|AFOLU")],
+        model_df.loc[pix.isin(variable="Emissions|CO2|AFOLU", region="World")],
+    ]
+)
+
+# %%
 pdf = pre_processing_res.global_workflow_emissions.loc[
     pix.ismatch(
         variable=[

--- a/scripts/drive-500x-series.py
+++ b/scripts/drive-500x-series.py
@@ -161,12 +161,12 @@ def main():  # noqa: PLR0912
     # All
     iams = [
         # "WITCH",
-        "REMIND",
+        # "REMIND",
         # "MESSAGE",
         # "IMAGE",
         # "GCAM",
         # "COFFEE",
-        # "AIM",
+        "AIM",
     ]
     # iams = ["COFFEE"]
 


### PR DESCRIPTION
This PR adds a fix for globally reported CO₂ AFOLU data, implementing a workaround introduced by @znichollscr.

"Now we are allowing data that is not complete and not internally consistent, the logic of the processing is broken. Hence we need the hack workaround above. I don't think this will affect any other species or sectors, but I could be wrong so please have a think."

I am still checking whether this is correct.