### PR TITLE
REMIND overrides from file

### DIFF
--- a/notebooks/5090_download-scenarios.py
+++ b/notebooks/5090_download-scenarios.py
@@ -96,8 +96,8 @@ props = conn_ssp.properties().reset_index()
 # %%
 to_download = props[props["model"].str.contains(model_search)]
 
-# if model_search == "REMIND":
-#     to_download = to_download[to_download["scenario"].str.endswith("- Very Low Emissions")]
+if model_search == "REMIND":
+    to_download = to_download[to_download["scenario"].str.endswith("- Very Low Emissions")]
 # if model_search == "AIM":
 #     to_download = to_download[to_download["scenario"].str.endswith("- Low Overshoot")]
 # if model_search == "MESSAGE":


### PR DESCRIPTION
Implement overrides for REMIND. It is the first attempt to read override from an external file provided by a team 
[harmonisation-methods_gridding_REMIND.csv](https://github.com/user-attachments/files/21431880/harmonisation-methods_gridding_REMIND.csv).

The file location is set to be `./data/interim/harmonisation_overrides` but may not be the best.

I thought that the methods with "*ratio*" should be handled differently form the others as they can brake the harmonisation where the other cannot(?).