### PR TITLE
MESSAGE overrides from file

### DIFF
--- a/notebooks/5090_download-scenarios.py
+++ b/notebooks/5090_download-scenarios.py
@@ -97,21 +97,22 @@ props = conn_ssp.properties().reset_index()
 to_download = props[props["model"].str.contains(model_search)]
 
 # if model_search == "REMIND":
-#     to_download = to_download[to_download["scenario"].str.endswith("- Very Low Emissions")]
-# if model_search == "AIM":
-#     # to_download = to_download[to_download["scenario"].str.endswith("- Low Overshoot")]
-#     to_download = to_download[to_download["scenario"].str.contains("- Low Overshoot")]
-if model_search == "MESSAGE":
-    to_download = to_download[to_download["scenario"].str.endswith("- Low Emissions")]
+#    laurin = ("SSP1 - Very Low Emissions", "SSP2 - Low Emissions", "SSP2 - Medium Emissions","SSP3 - High Emissions")
+#    to_download = to_download[to_download["scenario"].str.endswith(laurin)]
+if model_search == "AIM":
+    to_download = to_download[to_download["scenario"].str.contains("- Low Overshoot")]
+#    to_download = to_download[to_download["scenario"].str.endswith("- Low Overshoot_e")]
+# if model_search == "MESSAGE":
+# to_download = to_download[to_download["scenario"].str.endswith("SSP2 - Low Emissions")]
 # if model_search == "IMAGE":
-#     to_download = to_download[to_download["scenario"].str.endswith("- Medium Emissions")]
+#  to_download = to_download[to_download["scenario"].str.endswith("SSP2 - Medium Emissions")]
 # if model_search == "COFFEE":
 #     to_download = to_download[to_download["scenario"].str.endswith("- Medium-Low Emissions")]
 # if model_search == "GCAM":
 # to_download = to_download[to_download["scenario"].str.endswith("- High Emissions")]
 #   to_download = to_download[to_download["scenario"].str.contains("SSP3 - High Emissions")]
 # if model_search == "WITCH":
-#   to_download = to_download[to_download["scenario"].str.contains("- Medium-Low Emissions")]
+# to_download = to_download[to_download["scenario"].str.contains("- Medium-Low Emissions")]
 
 to_download.shape[0]
 

--- a/scripts/drive-500x-series.py
+++ b/scripts/drive-500x-series.py
@@ -160,13 +160,13 @@ def main():  # noqa: PLR0912
     # ]
     # All
     iams = [
-        # "WITCH",
-        # "REMIND",
-        "MESSAGE",
         # "IMAGE",
+        # "WITCH",
+        #  "REMIND",
+        # "MESSAGE",
         # "GCAM",
         # "COFFEE",
-        # "AIM",
+        "AIM",
     ]
     # iams = ["COFFEE"]
 
@@ -180,7 +180,7 @@ def main():  # noqa: PLR0912
     # Everything
     notebook_prefixes = ["5090", "5091", "5092", "5093", "5094"]
     # # Skip this step
-    notebook_prefixes = []
+    # notebook_prefixes = []
 
     for iam in tqdm.tqdm(iams, desc="IAMs pre infilling"):
         for notebook in all_notebooks:

--- a/src/emissions_harmonization_historical/constants_5000.py
+++ b/src/emissions_harmonization_historical/constants_5000.py
@@ -298,7 +298,7 @@ DOWNLOAD_SCENARIOS_ID = "0010-jk"
 # Run intermediary submission REMIND 20250617
 DOWNLOAD_SCENARIOS_ID = "0011-REMIND-jk"
 # Run 20250710 by Marco (prepared with/by Jarmo)
-DOWNLOAD_SCENARIOS_ID = "MESSAGE_tests"
+DOWNLOAD_SCENARIOS_ID = "overridfile_MESSAGE"
 
 # Database into which raw scenarios are saved
 RAW_SCENARIO_DB = OpenSCMDB(


### PR DESCRIPTION
Update on MESSAGE overrides that are now injected from a CSV file in the "data/raw/harmonisation_overrides/" folder.
The format is similar to REMIND’s, though not exactly the same. The main difference is that MESSAGE provides region-specific overrides.